### PR TITLE
Fix sitemap with verified crawlable routes

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,17 +1,45 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-<url><loc>https://samchakraborty.me/</loc><lastmod>2026-06-28</lastmod></url>
-<url><loc>https://samchakraborty.me/publications/</loc><lastmod>2026-06-28</lastmod></url>
-<url><loc>https://samchakraborty.me/projects/</loc><lastmod>2026-06-28</lastmod></url>
-<url><loc>https://samchakraborty.me/education/</loc><lastmod>2026-06-28</lastmod></url>
-<url><loc>https://samchakraborty.me/experience/</loc><lastmod>2026-06-28</lastmod></url>
-<url><loc>https://samchakraborty.me/blog/</loc><lastmod>2026-06-28</lastmod></url>
-<url><loc>https://samchakraborty.me/research/</loc><lastmod>2026-06-28</lastmod></url>
-<url><loc>https://samchakraborty.me/research/pibert/</loc><lastmod>2026-06-28</lastmod></url>
-<url><loc>https://samchakraborty.me/research/bubblefieldnet/</loc><lastmod>2026-06-28</lastmod></url>
-<url><loc>https://samchakraborty.me/research/llmpr/</loc><lastmod>2026-06-28</lastmod></url>
-<url><loc>https://samchakraborty.me/research/trust-health/</loc><lastmod>2026-06-28</lastmod></url>
-<url><loc>https://samchakraborty.me/research/comeback-researchers/</loc><lastmod>2026-06-28</lastmod></url>
-<url><loc>https://samchakraborty.me/research/physical-ai-pharmaceuticals/</loc><lastmod>2026-06-28</lastmod></url>
-<url><loc>https://samchakraborty.me/research/pacepal/</loc><lastmod>2026-06-28</lastmod></url>
+  <url>
+    <loc>https://samchakraborty.me/</loc>
+  </url>
+  <url>
+    <loc>https://samchakraborty.me/publications/</loc>
+  </url>
+  <url>
+    <loc>https://samchakraborty.me/projects/</loc>
+  </url>
+  <url>
+    <loc>https://samchakraborty.me/education/</loc>
+  </url>
+  <url>
+    <loc>https://samchakraborty.me/experience/</loc>
+  </url>
+  <url>
+    <loc>https://samchakraborty.me/blog/</loc>
+  </url>
+  <url>
+    <loc>https://samchakraborty.me/research/</loc>
+  </url>
+  <url>
+    <loc>https://samchakraborty.me/research/pibert/</loc>
+  </url>
+  <url>
+    <loc>https://samchakraborty.me/research/bubblefieldnet/</loc>
+  </url>
+  <url>
+    <loc>https://samchakraborty.me/research/pacepal/</loc>
+  </url>
+  <url>
+    <loc>https://samchakraborty.me/research/llmpr/</loc>
+  </url>
+  <url>
+    <loc>https://samchakraborty.me/research/trust-health/</loc>
+  </url>
+  <url>
+    <loc>https://samchakraborty.me/research/comeback-researchers/</loc>
+  </url>
+  <url>
+    <loc>https://samchakraborty.me/research/physical-ai-pharmaceuticals/</loc>
+  </url>
 </urlset>


### PR DESCRIPTION
## What changed

- inspected all physical HTML entry points in the repository
- retained only same-domain, crawlable pages that should appear in search
- included the homepage, section pages, research index, and all seven individual research-project pages
- excluded `404.html`, the unused `react-app/`, hash-only routes, Markdown source files, and external project websites
- removed the blanket `lastmod` dates because they were identical for every URL and were not individually verifiable
- kept `robots.txt` unchanged because it already points correctly to `https://samchakraborty.me/sitemap.xml`

No CSS, JavaScript, page content, images, or navigation structure was changed.